### PR TITLE
Redundant detect.py and now arguments for col names #109

### DIFF
--- a/pygrams.py
+++ b/pygrams.py
@@ -88,8 +88,8 @@ def get_args(command_line_arguments):
     parser.add_argument("-nf", "--num_ngrams_fdg", type=int, default=250,
                         help="number of ngrams to return for fdg graph")
 
-    parser.add_argument("-ds", "--doc_source", default='USPTO-random-100000.pkl.bz2', help="the doc source to process")
-    parser.add_argument("-fs", "--focus_source", default='USPTO-random-10000.pkl.bz2',
+    parser.add_argument("-ds", "--doc_source", default='USPTO-random-1000.pkl.bz2', help="the doc source to process")
+    parser.add_argument("-fs", "--focus_source", default='USPTO-random-1000.pkl.bz2',
                         help="the doc source for the focus function")
 
     parser.add_argument("-mn", "--min_n", type=int, choices=[1, 2, 3], default=1, help="the minimum ngram value")

--- a/pygrams.py
+++ b/pygrams.py
@@ -59,9 +59,9 @@ def get_args(command_line_arguments):
     parser.add_argument("-t", "--time", default=False, action="store_true", help="weight terms by time")
     parser.add_argument("-c", "--cite", default=False, action="store_true", help="weight terms by citations (for patents only)")
     parser.add_argument("-pt", "--path", default='data', help="the data path")
-    parser.add_argument("-ih", "--id_header", default='patent_id', help="the column name for the unique ID")
+    parser.add_argument("-ih", "--id_header", default=None, help="the column name for the unique ID")
     parser.add_argument("-th", "--text_header", default='abstract', help="the column name for the free text")
-    parser.add_argument("-dh", "--date_header", default='publication_date', help="the column name for the date")
+    parser.add_argument("-dh", "--date_header", default=None, help="the column name for the date")
     parser.add_argument("-fc", "--filter_columns", default=None, help="list of columns to filter by")
     parser.add_argument("-fb", "--filter_by", default='union', choices=['union', 'intersection'],
                         help="options are <all> <any> defaults to any. Returns filter where all are 'Yes' "

--- a/pygrams.py
+++ b/pygrams.py
@@ -88,7 +88,7 @@ def get_args(command_line_arguments):
     parser.add_argument("-nf", "--num_ngrams_fdg", type=int, default=250,
                         help="number of ngrams to return for fdg graph")
 
-    parser.add_argument("-ds", "--doc_source", default='USPTO-random-1000.pkl.bz2', help="the doc source to process")
+    parser.add_argument("-ds", "--doc_source", default='USPTO-random-100000.pkl.bz2', help="the doc source to process")
     parser.add_argument("-fs", "--focus_source", default='USPTO-random-10000.pkl.bz2',
                         help="the doc source for the focus function")
 
@@ -166,7 +166,8 @@ def run_report(args, ngram_multiplier, tfidf, tfidf_random=None, wordclouds=Fals
                docs_set=None, citation_count_dict=None):
     num_ngrams = max(args.num_ngrams_report, args.num_ngrams_wordcloud)
 
-    tfocus = TermFocus(tfidf, tfidf_random)
+    tfocus = TermFocus(tfidf, tfidf_random, id_header=args.id_header,
+                 text_header=args.text_header, date_header=args.date_header)
     dict_freqs, focus_set_terms, _ = tfocus.detect_and_focus_popular_ngrams(args, citation_count_dict, ngram_multiplier,
                                                                             num_ngrams, docs_set=docs_set)
     with open(args.report_name, 'w') as file:

--- a/pygrams.py
+++ b/pygrams.py
@@ -59,9 +59,9 @@ def get_args(command_line_arguments):
     parser.add_argument("-t", "--time", default=False, action="store_true", help="weight terms by time")
     parser.add_argument("-c", "--cite", default=False, action="store_true", help="weight terms by citations (for patents only)")
     parser.add_argument("-pt", "--path", default='data', help="the data path")
-    parser.add_argument("-ih", "--id_header", default='id', help="the column name for the unique ID")
-    parser.add_argument("-th", "--text_header", default='text', help="the column name for the free text")
-    parser.add_argument("-dh", "--date_header", default='date', help="the column name for the date")
+    parser.add_argument("-ih", "--id_header", default='patent_id', help="the column name for the unique ID")
+    parser.add_argument("-th", "--text_header", default='abstract', help="the column name for the free text")
+    parser.add_argument("-dh", "--date_header", default='publication_date', help="the column name for the date")
     parser.add_argument("-fc", "--filter_columns", default=None, help="list of columns to filter by")
     parser.add_argument("-fb", "--filter_by", default='union', choices=['union', 'intersection'],
                         help="options are <all> <any> defaults to any. Returns filter where all are 'Yes' "

--- a/pygrams.py
+++ b/pygrams.py
@@ -49,7 +49,7 @@ def year2pandas_earliest_date(year_in, month_in):
 
 
 def get_args(command_line_arguments):
-    parser = argparse.ArgumentParser(description="create report, wordcloud, and fdg graph for document abstracts")
+    parser = argparse.ArgumentParser(description="create report, wordcloud, and fdg graph for free text in documents")
 
     parser.add_argument("-f", "--focus", default=None, choices=['set', 'chi2', 'mutual'],
                         help="clean output from terms that appear in general; 'set': set difference, "
@@ -57,8 +57,11 @@ def get_args(command_line_arguments):
                              "'mutual': mutual information for feature importance")
     parser.add_argument("-ndl", "--normalize_doc_length", default=False, action="store_true", help="normalize tf-idf scores by document length")
     parser.add_argument("-t", "--time", default=False, action="store_true", help="weight terms by time")
+    parser.add_argument("-c", "--cite", default=False, action="store_true", help="weight terms by citations (for patents only)")
     parser.add_argument("-pt", "--path", default='data', help="the data path")
-    parser.add_argument("-ah", "--abstract_header", default='abstract', help="the data path")
+    parser.add_argument("-ih", "--id_header", default='id', help="the column name for the unique ID")
+    parser.add_argument("-th", "--text_header", default='text', help="the column name for the free text")
+    parser.add_argument("-dh", "--date_header", default='date', help="the column name for the date")
     parser.add_argument("-fc", "--filter_columns", default=None, help="list of columns to filter by")
     parser.add_argument("-fb", "--filter_by", default='union', choices=['union', 'intersection'],
                         help="options are <all> <any> defaults to any. Returns filter where all are 'Yes' "
@@ -114,7 +117,7 @@ def get_tfidf(args, pickle_file_name, df=None):
     date_from = year2pandas_earliest_date(args.year_from, args.month_from)
     date_to = year2pandas_latest_date(args.year_to, args.month_to)
     if df is None or args.year_from is not None or args.year_to is not None:
-        df = PatentsPickle2DataFrame(pickle_file_name, date_from=date_from, date_to=date_to).data_frame
+        df = PatentsPickle2DataFrame(pickle_file_name, date_from=date_from, date_to=date_to, date_header=args.date_header).data_frame
     header_filter_cols = [x.strip() for x in args.filter_columns.split(",")] if args.filter_columns is not None else []
     header_lists = []
     doc_set = None
@@ -134,21 +137,33 @@ def get_tfidf(args, pickle_file_name, df=None):
             else:
                 doc_set = doc_set.union(set(indices))
 
-    return TFIDF(df, tokenizer=LemmaTokenizer(), ngram_range=(args.min_n, args.max_n), header=args.abstract_header, normalize_doc_length = args.normalize_doc_length,
-                 max_document_frequency=args.max_document_frequency), doc_set
+    return TFIDF(df, tokenizer=LemmaTokenizer(), ngram_range=(args.min_n, args.max_n), id_header=args.id_header,
+                 text_header=args.text_header, date_header=args.date_header,
+                 normalize_doc_length = args.normalize_doc_length, max_document_frequency=args.max_document_frequency), doc_set
 
 
-def run_table(args, ngram_multiplier, tfidf, tfidf_random):
+def load_citation_count_dict():
+
+    citation_count_dict = pd.read_pickle(os.path.join('data/USPTO-citation-dictionary-family-pt1.pkl.bz2'))
+    citation_count_dict_pt2 = pd.read_pickle(os.path.join('data/USPTO-citation-dictionary-family-pt2.pkl.bz2'))
+    citation_count_dict.update(citation_count_dict_pt2)
+    return citation_count_dict
+
+def run_table(args, ngram_multiplier, tfidf, tfidf_random, citation_count_dict=None):
+
+    if citation_count_dict is None:
+        citation_count_dict = load_citation_count_dict()
+
     num_ngrams = max(args.num_ngrams_report, args.num_ngrams_wordcloud)
     print(f'Writing table to {args.table_name}')
     writer = ExcelWriter(args.table_name, engine='xlsxwriter')
 
-    table_output(tfidf, tfidf_random, num_ngrams, args, ngram_multiplier, writer)
+    table_output(tfidf, tfidf_random, num_ngrams, args, ngram_multiplier, writer, citation_count_dict=citation_count_dict)
 
 
 # TODO: common interface wrapper class, hence left citation_count_dict refs
-def run_report(args, ngram_multiplier, tfidf, tfidf_random=None, wordclouds=False, citation_count_dict=None,
-               docs_set=None):
+def run_report(args, ngram_multiplier, tfidf, tfidf_random=None, wordclouds=False,
+               docs_set=None, citation_count_dict=None):
     num_ngrams = max(args.num_ngrams_report, args.num_ngrams_wordcloud)
 
     tfocus = TermFocus(tfidf, tfidf_random)
@@ -198,6 +213,7 @@ def write_config_to_json(args, doc_pickle_file_name):
         'parameters': {
             'pick': args.pick,
             'time': args.time,
+            'cite': args.cite,
             'focus': args.focus
         }
     }
@@ -209,24 +225,24 @@ def write_config_to_json(args, doc_pickle_file_name):
 def output_tfidf(tfidf_base_filename, tfidf):
 
     try:
-        publication_week_dates = [iso_date[0] * 100 + iso_date[1] for iso_date in
-                                  [d.isocalendar() for d in tfidf.publication_dates]]
+        document_week_dates = [iso_date[0] * 100 + iso_date[1] for iso_date in
+                                  [d.isocalendar() for d in tfidf.dates]]
     except KeyError:
-        publication_week_dates = pd.Series(None, index=np.arange(len(tfidf.feature_names)))
+        document_week_dates = pd.Series(None, index=np.arange(len(tfidf.feature_names)))
 
     try:
-        patent_ids = tfidf.patent_ids
+        doc_ids = tfidf.doc_ids
     except KeyError:
-        patent_ids = pd.Series(None, index=np.arange(len(tfidf.feature_names)))
+        doc_ids = pd.Series(None, index=np.arange(len(tfidf.feature_names)))
 
-    tfidf_data = [tfidf.tfidf_matrix, tfidf.feature_names, publication_week_dates, patent_ids]
+    tfidf_data = [tfidf.tfidf_matrix, tfidf.feature_names, document_week_dates, doc_ids]
     tfidf_filename = os.path.join('outputs', 'tfidf', tfidf_base_filename + '-tfidf.pkl.bz2')
     os.makedirs(os.path.dirname(tfidf_filename), exist_ok=True)
     with bz2.BZ2File(tfidf_filename, 'wb') as pickle_file:
         pickle.dump(tfidf_data, pickle_file)
 
     term_present_matrix = tfidf.tfidf_matrix > 0
-    term_present_data = [term_present_matrix, tfidf.feature_names, publication_week_dates, patent_ids]
+    term_present_data = [term_present_matrix, tfidf.feature_names, document_week_dates, doc_ids]
     term_present_filename = os.path.join('outputs', 'tfidf', tfidf_base_filename + '-term_present.pkl.bz2')
     os.makedirs(os.path.dirname(term_present_filename), exist_ok=True)
     with bz2.BZ2File(term_present_filename, 'wb') as pickle_file:
@@ -235,13 +251,13 @@ def output_tfidf(tfidf_base_filename, tfidf):
 
 def output_term_counts(tfidf_base_filename, tfidf):
 
-    publication_week_dates = [iso_date[0] * 100 + iso_date[1] for iso_date in
-                              [d.isocalendar() for d in tfidf.publication_dates]]
+    document_week_dates = [iso_date[0] * 100 + iso_date[1] for iso_date in
+                              [d.isocalendar() for d in tfidf.dates]]
 
-    term_counts_per_week, number_of_patents_per_week, week_iso_dates = tfidf_with_dates_to_weekly_term_counts(
-        tfidf.tfidf_matrix, publication_week_dates)
+    term_counts_per_week, number_of_documents_per_week, week_iso_dates = tfidf_with_dates_to_weekly_term_counts(
+        tfidf.tfidf_matrix, document_week_dates)
 
-    term_counts_data = [term_counts_per_week, tfidf.feature_names, number_of_patents_per_week, week_iso_dates]
+    term_counts_data = [term_counts_per_week, tfidf.feature_names, number_of_documents_per_week, week_iso_dates]
     term_counts_filename = os.path.join('outputs', 'termcounts', tfidf_base_filename + '-term_counts.pkl.bz2')
     os.makedirs(os.path.dirname(term_counts_filename), exist_ok=True)
     with bz2.BZ2File(term_counts_filename, 'wb') as pickle_file:
@@ -267,9 +283,11 @@ def main():
     elif doc_source_file_name[len(doc_source_file_name) - 3:] == 'xls':
         df = pd.read_excel(doc_source_file_name)
     elif doc_source_file_name[len(doc_source_file_name) - 3:] == 'csv':
-        df = pd.read_csv(doc_source_file_name)
+        df = pd.read_csv(doc_source_file_name, engine='python', error_bad_lines=False, nrows=10000)
     elif doc_source_file_name[len(doc_source_file_name) - 4:] == 'xlsx':
         df = pd.read_excel(doc_source_file_name)
+
+    argscheck.checkdf(df)
 
     if isinstance(args.filter_columns, type(None)):
         docs_set = None
@@ -305,14 +323,20 @@ def main():
         newtfidf, _ = get_tfidf(args, path2, None)
 
     out = args.output
+
+    citation_count_dict = None
+    if args.cite:
+        citation_count_dict = load_citation_count_dict()
+
     ngram_multiplier = 4
 
     if out != 'tfidf':
         wordclouds_flag = (out == 'wordcloud')
-        dict_freqs = run_report(args, ngram_multiplier, tfidf, newtfidf, wordclouds=wordclouds_flag, docs_set=doc_set)
+        dict_freqs = run_report(args, ngram_multiplier, tfidf, newtfidf, wordclouds=wordclouds_flag, docs_set=doc_set,
+                                citation_count_dict=citation_count_dict)
 
     if out == 'table' or out == 'all':
-        run_table(args, ngram_multiplier, tfidf, newtfidf)
+        run_table(args, ngram_multiplier, tfidf, newtfidf, citation_count_dict=citation_count_dict)
 
     if out == 'fdg' or out == 'all':
         run_fdg(dict_freqs, tfidf, args)

--- a/scripts/algorithms/term_focus.py
+++ b/scripts/algorithms/term_focus.py
@@ -4,9 +4,14 @@ from sklearn.feature_selection import SelectKBest, chi2, mutual_info_classif
 
 class TermFocus():
 
-    def __init__(self, tf_idf_in, tf_idf_random_in):
+    def __init__(self, tf_idf_in, tf_idf_random_in, id_header='patent_id', text_header='abstract',
+                 date_header='publication_date'):
+
         self.__tfidf = tf_idf_in
         self.__tfidf_random = tf_idf_random_in
+        self.__id_header = id_header
+        self.__text_header = text_header
+        self.__date_header = date_header
 
     def detect_and_focus_popular_ngrams(self,args, citation_count_dict, ngram_multiplier, num_ngrams, docs_set=None):
         pick = args.pick
@@ -69,12 +74,12 @@ class TermFocus():
 
 
     def __popular_ngrams_with_selectkbest(self, num_ngrams_report, score_func):
-        df = pd.DataFrame(self.__tfidf.abstracts, columns=['abstract'])
-        df2 = pd.DataFrame(self.__tfidf_random.abstracts, columns=['abstract'])
+        df = pd.DataFrame(self.__tfidf.text, columns=[self.__text_header])
+        df2 = pd.DataFrame(self.__tfidf_random.text, columns=[self.__text_header])
         df['class_flag'] = 'Yes'
         df2['class_flag'] = 'No'
         df = pd.concat([df, df2])  # , sort=True)
-        X = df['abstract'].values.astype('U')
+        X = df[self.__text_header].values.astype('U')
         y = df['class_flag'].values.astype('U')
 
         ch2 = SelectKBest(score_func, k=num_ngrams_report)

--- a/scripts/algorithms/tfidf.py
+++ b/scripts/algorithms/tfidf.py
@@ -151,7 +151,8 @@ class WordAnalyzer(object):
 
 
 class TFIDF:
-    def __init__(self, docs_df, ngram_range=(1, 3), max_document_frequency=0.3, tokenizer=StemTokenizer(), header='abstract', normalize_doc_length=False, uni_factor=0.8):
+    def __init__(self, docs_df, ngram_range=(1, 3), max_document_frequency=0.3, tokenizer=StemTokenizer(),
+                 id_header='id', text_header='text', date_header='date', normalize_doc_length=False, uni_factor=0.8):
         self.__dataframe = docs_df
 
         WordAnalyzer.init(
@@ -166,16 +167,18 @@ class TFIDF:
             analyzer=WordAnalyzer.analyzer
         )
 
-        self.__abstract_header = header
+        self.__id_header = id_header
+        self.__text_header = text_header
+        self.__date_header = date_header
         self.__uni_factor = uni_factor
 
         num_docs_before_sift = self.__dataframe.shape[0]
-        self.__dataframe.dropna(subset=[self.__abstract_header], inplace=True)
+        self.__dataframe.dropna(subset=[self.__text_header], inplace=True)
         num_docs_after_sift = self.__dataframe.shape[0]
         num_docs_sifted = num_docs_before_sift - num_docs_after_sift
-        print(f'Dropped {num_docs_sifted:,} docs due to empty abstracts')
+        print(f'Dropped {num_docs_sifted:,} docs due to empty text field')
 
-        self.__ngram_counts = self.__vectorizer.fit_transform(self.__dataframe[self.__abstract_header])
+        self.__ngram_counts = self.__vectorizer.fit_transform(self.__dataframe[self.__text_header])
         self.__feature_names = self.__vectorizer.get_feature_names()
 
         if normalize_doc_length:
@@ -203,20 +206,20 @@ class TFIDF:
         return self.__vectorizer
 
     @property
-    def abstracts(self):
-        return self.__dataframe[self.__abstract_header]
+    def text(self):
+        return self.__dataframe[self.__text_header]
 
     @property
     def feature_names(self):
         return self.__feature_names
 
     @property
-    def publication_dates(self):
-        return list(self.__dataframe['publication_date'])
+    def dates(self):
+        return list(self.__dataframe[self.__date_header])
 
     @property
-    def patent_ids(self):
-        return list(self.__dataframe['patent_id'])
+    def doc_ids(self):
+        return list(self.__dataframe[self.__id_header])
 
     def detect_popular_ngrams_in_docs_set(self, number_of_ngrams_to_return=200, pick='sum', time=False,
                                           citation_count_dict=None, docs_set=None):
@@ -224,7 +227,7 @@ class TFIDF:
             print(f'Processing TFIDF of {self.__tfidf_matrix.shape[0]:,} documents')
 
         if self.__tfidf_matrix.shape[0] == 0:
-            print('...skipping as 0 patents...')
+            print('...skipping as 0 documents...')
             return []
 
         if self.__lost_state:
@@ -238,20 +241,20 @@ class TFIDF:
 
 
         if time:
-            self.__dataframe = self.__dataframe.sort_values(by=['publication_date'])
+            self.__dataframe = self.__dataframe.sort_values(by=[self.__date_header])
             epoch = datetime.datetime.utcfromtimestamp(0)
-            num_docs = len(self.__dataframe['publication_date'])
+            num_docs = len(self.__dataframe[self.__date_header])
             time_weights = [0.0] * num_docs
-            for patent_index, pub_date in enumerate(self.__dataframe['publication_date']):
-                time_weights[patent_index] = (pub_date - epoch).total_seconds()
+            for id_index, date in enumerate(self.__dataframe[self.__date_header]):
+                time_weights[id_index] = (date - epoch).total_seconds()
 
             mx = max(time_weights)
             mn = min(time_weights)
 
-            for patent_index, pub_date in enumerate(self.__dataframe['publication_date']):
-                X = time_weights[patent_index]
+            for id_index, date in enumerate(self.__dataframe[self.__date_header]):
+                X = time_weights[id_index]
                 X_std = (X - mn) / (mx - mn)
-                time_weights[patent_index] = X_std
+                time_weights[id_index] = X_std
 
             for i, v in enumerate(time_weights):
                 self.__tfidf_matrix.data[self.__tfidf_matrix.indptr[i]:self.__tfidf_matrix.indptr[i + 1]] *= v
@@ -259,25 +262,25 @@ class TFIDF:
 
         if citation_count_dict:
             #TODO check if we need -2 below. If not, we only need one dict for both citations and docs_set
-            patent_id_dict = {k[:-2]: v for v, k in enumerate(self.__dataframe.patent_id)}
-            citation_count_for_patent_id_dict = {}
-            for key, _ in tqdm(patent_id_dict.items()):
-                citation_count_for_patent_id_dict[key] = citation_count_dict.get(key, .0)
+            doc_id_dict = {k[:-2]: v for v, k in enumerate(self.__dataframe[self.__id_header])}
+            citation_count_for_doc_id_dict = {}
+            for key, _ in tqdm(doc_id_dict.items()):
+                citation_count_for_doc_id_dict[key] = citation_count_dict.get(key, .0)
 
-            max_citation_count_val = float(max(citation_count_for_patent_id_dict.values()))
+            max_citation_count_val = float(max(citation_count_for_doc_id_dict.values()))
             min_citation_count_val = 0.05
 
             if max_citation_count_val == 0:
-                for patent_id in citation_count_for_patent_id_dict:
-                    citation_count_for_patent_id_dict[patent_id] = 1.0
+                for doc_id in citation_count_for_doc_id_dict:
+                    citation_count_for_doc_id_dict[doc_id] = 1.0
             else:
-                for patent_id in citation_count_for_patent_id_dict:
-                    citation_count_for_patent_id_dict_std = min_citation_count_val + (
-                            (float(citation_count_for_patent_id_dict[patent_id]) - min_citation_count_val) / (
+                for doc_id in citation_count_for_doc_id_dict:
+                    citation_count_for_doc_id_dict_std = min_citation_count_val + (
+                            (float(citation_count_for_doc_id_dict[doc_id]) - min_citation_count_val) / (
                             max_citation_count_val - min_citation_count_val))
-                    citation_count_for_patent_id_dict[patent_id] = citation_count_for_patent_id_dict_std
+                    citation_count_for_doc_id_dict[doc_id] = citation_count_for_doc_id_dict_std
 
-            list_of_citation_counts = list(citation_count_for_patent_id_dict.values())
+            list_of_citation_counts = list(citation_count_for_doc_id_dict.values())
 
             for i, v in enumerate(list_of_citation_counts):
                 self.__tfidf_matrix.data[self.__tfidf_matrix.indptr[i]:self.__tfidf_matrix.indptr[i + 1]] *= v
@@ -335,7 +338,7 @@ class TFIDF:
     def __clean_unigrams(self, max_bi_freq, factor):
 
         # iterate through rows ( docs)
-        for i in range(len(self.abstracts)):
+        for i in range(len(self.text)):
             start_idx_ptr = self.__tfidf_matrix.indptr[i]
             end_idx_ptr = self.__tfidf_matrix.indptr[i + 1]
 
@@ -354,7 +357,7 @@ class TFIDF:
     def __max_bigram(self):
         max_tf = 0.0
         # iterate through rows ( docs)
-        for i in range(len(self.abstracts)):
+        for i in range(len(self.text)):
             start_idx_ptr = self.__tfidf_matrix.indptr[i]
             end_idx_ptr = self.__tfidf_matrix.indptr[i + 1]
 
@@ -372,14 +375,14 @@ class TFIDF:
 
     def __normalize_rows(self):
 
-        for idx, text in enumerate(self.abstracts):
+        for idx, text in enumerate(self.text):
             text_len = len(text)
             self.__ngram_counts.data[self.__ngram_counts.indptr[idx]: self.__ngram_counts.indptr[idx + 1]] /= text_len
 
     def __unbias_ngrams(self, ngram_length):
 
         # iterate through rows ( docs)
-        for i in range(len(self.abstracts)):
+        for i in range(len(self.text)):
             start_idx_ptr = self.__tfidf_matrix.indptr[i]
             end_idx_ptr = self.__tfidf_matrix.indptr[i + 1]
 

--- a/scripts/algorithms/tfidf.py
+++ b/scripts/algorithms/tfidf.py
@@ -152,7 +152,7 @@ class WordAnalyzer(object):
 
 class TFIDF:
     def __init__(self, docs_df, ngram_range=(1, 3), max_document_frequency=0.3, tokenizer=StemTokenizer(),
-                 id_header='id', text_header='text', date_header='date', normalize_doc_length=False, uni_factor=0.8):
+                 id_header='patent_id', text_header='abstract', date_header='publication_date', normalize_doc_length=False, uni_factor=0.8):
         self.__dataframe = docs_df
 
         WordAnalyzer.init(

--- a/scripts/utils/argschecker.py
+++ b/scripts/utils/argschecker.py
@@ -106,8 +106,8 @@ class ArgsChecker():
     def checkdf(self, df):
         app_exit = False
 
-        if self.args.id_header == 'none':
-            print(f"id column is empty, will construct an id column")
+        if self.args.id_header is None:
+            print(f"id_header not provided, will construct an id column")
             df.insert(0, 'id', range(0, 0 + len(df)))
             self.args.id_header = 'id'
             app_exit = False

--- a/scripts/utils/argschecker.py
+++ b/scripts/utils/argschecker.py
@@ -130,5 +130,10 @@ class ArgsChecker():
                 print(f"date_header '{self.args.date_header}' not in dataframe")
                 app_exit = True
 
+        if self.args.output == 'termcounts':
+            if self.args.date_header not in df.columns:
+                print(f"cannot output termcounts without a specifying a date column")
+                app_exit = True
+
         if app_exit:
             exit(0)

--- a/scripts/utils/argschecker.py
+++ b/scripts/utils/argschecker.py
@@ -6,6 +6,7 @@ class ArgsChecker():
 
     def checkargs(self):
         app_exit = False
+
         if isinstance(self.args.year_to, str) & isinstance(self.args.year_from, str):
             if isinstance(self.args.month_to, str) & isinstance(self.args.month_from, str):
                 if self.args.year_from + self.args.month_from > self.args.year_to + self.args.month_to:
@@ -96,6 +97,31 @@ class ArgsChecker():
         if self.args.table_name != self.args_default.table_name:
             if self.args.output != 'table' or self.args.output != 'all':
                 print('argument [-tn] can only be used when output includes table [-o] "table" or "all"')
+                app_exit = True
+
+
+        if app_exit:
+            exit(0)
+
+    def checkdf(self, df):
+        app_exit = False
+
+        if self.args.id_header not in df.columns:
+            print(f"id_header '{self.args.id_header}' not in dataframe")
+            app_exit = True
+
+        if self.args.text_header not in df.columns:
+            print(f"text_header '{self.args.text_header}' not in dataframe")
+            app_exit = True
+
+        if isinstance(self.args.year_from, str):
+            if self.args.date_header not in df.columns:
+                print(f"date_header '{self.args.date_header}' not in dataframe")
+                app_exit = True
+
+        if isinstance(self.args.year_to, str):
+            if self.args.date_header not in df.columns:
+                print(f"date_header '{self.args.date_header}' not in dataframe")
                 app_exit = True
 
         if app_exit:

--- a/scripts/utils/argschecker.py
+++ b/scripts/utils/argschecker.py
@@ -106,6 +106,12 @@ class ArgsChecker():
     def checkdf(self, df):
         app_exit = False
 
+        if self.args.id_header == 'none':
+            print(f"id column is empty, will construct an id column")
+            df.insert(0, 'id', range(0, 0 + len(df)))
+            self.args.id_header = 'id'
+            app_exit = False
+
         if self.args.id_header not in df.columns:
             print(f"id_header '{self.args.id_header}' not in dataframe")
             app_exit = True

--- a/scripts/utils/pickle2df.py
+++ b/scripts/utils/pickle2df.py
@@ -6,11 +6,12 @@ from tqdm import tqdm
 
 class PatentsPickle2DataFrame(object):
     def __init__(self, data_frame_pickle_file_name, date_from=None, date_to=None, classification=None,
-                 pickle_reader=pd.read_pickle, print_func=print):
+                 pickle_reader=pd.read_pickle, date_header='date', print_func=print):
 
         self.__print_func = print_func
         self.__data_frame = pickle_reader(data_frame_pickle_file_name)
         self.__data_frame.reset_index(inplace=True, drop=True)
+        self.__date_header = date_header
 
         if date_from is not None and date_to is not None:
             self.__subset_dates(date_from, date_to)
@@ -30,13 +31,13 @@ class PatentsPickle2DataFrame(object):
         _date_from = pd.Timestamp(date_from)
         _date_to = pd.Timestamp(date_to)
 
-        self.__data_frame.sort_values('publication_date', inplace=True)
+        self.__data_frame.sort_values(self.__date_header, inplace=True)
         self.__print_func(f'Sifting documents between {_date_from.strftime("%d-%b-%Y")} and'
                           f' {_date_to.strftime("%d-%b-%Y")}')
 
-        self.__data_frame.drop(self.__data_frame[(self.__data_frame.publication_date < _date_from) | (
-                self.__data_frame.publication_date > _date_to)].index, inplace=True)
-        self.__print_func(f'{self.__data_frame.shape[0]:,} documents available after publication date sift')
+        self.__data_frame.drop(self.__data_frame[(self.__data_frame[self.__date_header] < _date_from) | (
+                self.__data_frame[self.__date_header] > _date_to)].index, inplace=True)
+        self.__print_func(f'{self.__data_frame.shape[0]:,} documents available after date sift')
 
         self.__data_frame.reset_index(inplace=True, drop=True)
 

--- a/scripts/utils/pickle2df.py
+++ b/scripts/utils/pickle2df.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 class PatentsPickle2DataFrame(object):
     def __init__(self, data_frame_pickle_file_name, date_from=None, date_to=None, classification=None,
-                 pickle_reader=pd.read_pickle, date_header='date', print_func=print):
+                 pickle_reader=pd.read_pickle, date_header='publication_date', print_func=print):
 
         self.__print_func = print_func
         self.__data_frame = pickle_reader(data_frame_pickle_file_name)

--- a/tests/utils/test_pickle2df.py
+++ b/tests/utils/test_pickle2df.py
@@ -53,7 +53,7 @@ class TestPatentsPickle2DataFrame(unittest.TestCase):
         self.assertEqual(1, data_frame.shape[0])
         self.assertEqual('patent 2', data_frame.loc[0].invention_title)
         self.assertEqual('Sifting documents between 01-Jan-1999 and 07-Jul-2007\n'
-                         '1 documents available after publication date sift\n', self.print_output)
+                         '1 documents available after date sift\n', self.print_output)
 
     def test_filters_by_from_date_if_not_None(self):
         date_from = '2003-01-22'
@@ -71,4 +71,4 @@ class TestPatentsPickle2DataFrame(unittest.TestCase):
         self.assertEqual('patent 1', data_frame.loc[0].invention_title)
         self.assertEqual('patent 3', data_frame.loc[1].invention_title)
         self.assertEqual('Sifting documents between 22-Jan-2003 and 01-Feb-2020\n'
-                         '2 documents available after publication date sift\n', self.print_output)
+                         '2 documents available after date sift\n', self.print_output)


### PR DESCRIPTION
Two main features:

1. detect.py is pretty much redundant now as all features *should* be in pygrams.py, including citation analysis
2. users can now specify the column names of:
- the ID column (formally patent_id, default now is 'id')
- the free text column (formally abstract, default now is 'text')
- the date column (formally publication_dates, default now is 'dates')

```
    parser.add_argument("-ih", "--id_header", default='id', help="the column name for the unique ID")
    parser.add_argument("-th", "--text_header", default='text', help="the column name for the free text")
    parser.add_argument("-dh", "--date_header", default='date', help="the column name for the date")
```

I have traced through the code and made sure all things 'patent' related in tfidf.py and pickle2df.py have been removed to make it more generic.

Have tested on the following (all CSV files):

- Tweet corpus: https://www.kaggle.com/thoughtvector/customer-support-on-twitter (10,000 rows)
- Book reviews: https://www.kaggle.com/gnanesh/goodreads-book-reviews/version/2 (10,000 rows)
- News headline: https://www.kaggle.com/sunnysai12345/news-summary

And all works fine. Returning desired outputs for all.

Hopefully this will tie in well with my new documentation (another PR) and make pygrams.py more generic for anyone that wants to use it to analyse free text.

